### PR TITLE
Spell know checks improvement for load condition.

### DIFF
--- a/Clicked/Core/BindingProcessor.lua
+++ b/Clicked/Core/BindingProcessor.lua
@@ -898,11 +898,11 @@ function Addon:CanBindingLoad(binding)
 		local spellKnown = load.spellKnown
 
 		if spellKnown.selected then
-			local name = Addon:GetSpellInfo(spellKnown.value)
-
-			if name == nil then
+			local name, _, _, _, _, _, spellId = Addon:GetSpellInfo(spellKnown.value)			
+			if name == nil or spellId == nil then
 				return false
 			end
+			return IsSpellKnown(spellId)
 		end
 	end
 


### PR DESCRIPTION
Spell know checked if the spell exist but it didn't check if the spell is known.

Now the process checks if the spell exist and known.

This is a proposal for the issue: https://github.com/Snakybo/Clicked/issues/129