### PR TITLE
Add (Dragonriding) to dragonriding spells to remove collisions with D…

### DIFF
--- a/Clicked/Core/Utils.lua
+++ b/Clicked/Core/Utils.lua
@@ -667,6 +667,13 @@ function Addon:GetSpellInfo(input, addSubText)
 		end
 	end
 
+	if Addon:IsGameVersionAtleast("RETAIL") then
+		local dragonRidingSpells = { 372608, 372610, 361584, 374990, 403216 }
+		if tContains(dragonRidingSpells, spellId) then
+			name = string.format("%s(%s)", name, "Dragonriding")
+		end
+	end
+
 	return name, rank, icon, castTime, minRange, maxRange, spellId
 end
 


### PR DESCRIPTION
…racthyr spells.

Some dragonriding spells have the same name as Dracthyr soar spells, so to remove collisions you need to add (Dragonriding) to them.  I don't know if this needs to be localized.  I tested this on a dracthyr preservation evoker, and all 5 bindings work with this change.  Without this change Surge Forward and Skyward Ascent notably dont work, I dont know if the other three wouldnt but it also doesnt hurt to treat them the same.