### PR TITLE
Fix talent load condition when selecting hero tree talents

### DIFF
--- a/Clicked/Core/BindingProcessor.lua
+++ b/Clicked/Core/BindingProcessor.lua
@@ -897,6 +897,14 @@ function Addon:UpdateTalentCache(callback, immediate)
 						end
 					end
 
+					-- check if the node is part of a hero talent tree that is currently selected
+					if isValid and nodeInfo.subTreeID then
+						local subTreeInfo = C_Traits.GetSubTreeInfo(configId, nodeInfo.subTreeID)
+						if not subTreeInfo.isActive then
+							isValid = false
+						end
+					end
+
 					if isValid then
 						local entryId = nodeInfo.activeEntry ~= nil and nodeInfo.activeEntry.entryID or 0
 						local entryInfo = entryId ~= nil and C_Traits.GetEntryInfo(configId, entryId) or nil


### PR DESCRIPTION
This PR introduces a fix for a bug where selecting a talent from a hero talent tree results in "always passed" condition if the talent was picked once regardless of currently selected hero talent tree. The issue arises when checked talent is from an inactive hero talent tree, which should not be recognized as selected.

Tested this change with my Warrior and Pala and selecting hero talents for talent load condition now works as expected.

Will fix #243 