### PR TITLE
Fixes and improvements to import process

### DIFF
--- a/Clicked/BindingConfig/Pages/ImportString.lua
+++ b/Clicked/BindingConfig/Pages/ImportString.lua
@@ -218,7 +218,13 @@ function Addon.BindingConfig.ImportStringPage:RedrawToReview()
 			end
 
 			Clicked:Import(review)
-			self.controller:PopPage(self)
+			if review.type == "group" then
+				Addon.BindingConfig.Window:Select(review.group.uid)
+			elseif review.type == "binding" then
+				Addon.BindingConfig.Window:Select(review.binding.uid)
+			else
+				self.controller:PopPage(self)
+			end
 		end)
 
 		self.container:AddChild(widget)

--- a/Clicked/Core/Serializer.lua
+++ b/Clicked/Core/Serializer.lua
@@ -44,11 +44,13 @@ local function RegisterGroup(data)
 
 	local bindings = data.group.bindings
 	data.group.bindings = nil
+	data.group.uid = nil
 
 	Addon:RegisterDataObject(data.group)
 
 	for _, binding in ipairs(bindings) do
 		binding.parent = data.group.uid
+		binding.uid = nil
 
 		Addon:RegisterDataObject(binding)
 		Addon:ReloadBinding(binding, true)
@@ -60,7 +62,7 @@ local function RegisterBinding(data)
 	if data.type ~= "binding" then
 		error("bad argument #1, expected binding but got " .. data.type)
 	end
-
+	data.binding.uid = nil
 	Addon:RegisterDataObject(data.binding, Clicked.DataObjectScope.PROFILE)
 	Addon:ReloadBinding(data.binding, true)
 end


### PR DESCRIPTION
## Prevent uid duplication when importing binding or group
Currently when importing a string uid from the imported data is used, which may result in uid duplications.

## Select binding or group instead of closing window on import
Currently when pressing `Import` addon's options are closed which results in poor UX