### PR TITLE
When converting spell to macro, try pre-define name, icon and a "/cast" in macro.

### DIFF
--- a/Clicked/BindingConfig/BindingConfig.lua
+++ b/Clicked/BindingConfig/BindingConfig.lua
@@ -962,6 +962,22 @@ function Addon.BindingConfig.Window:CreateTreeFrame()
 							for _, binding in ipairs(objects) do
 								if binding.actionType ~= type then
 									first = first or binding
+
+									-- When converting spell to macro, try pre-define name, icon and a "/cast" in macro.
+									if binding.actionType == Clicked.ActionType.SPELL and type == Clicked.ActionType.MACRO then
+										if binding.action.spellValue then
+											local spellName = C_Spell.GetSpellName(binding.action.spellValue)
+											local iconId, _ = C_Spell.GetSpellTexture(binding.action.spellValue)
+											if spellName then
+												binding.action.macroName = "Cast " .. spellName .. " (Macro)"
+												binding.action.macroValue = "/cast " .. spellName
+											end
+											if iconId then
+												binding.action.macroIcon = iconId
+											end
+										end
+									end
+									
 									binding.actionType = type
 
 									Addon:ReloadBinding(binding, true)


### PR DESCRIPTION
Reason for this pull request:

When I'm converting a spell binding to macro, I expect it initially doing similar things before and after the conversion. Also it does not make sense when I convert a spell to macro it gives me empty macro.

Video Demo:

https://github.com/user-attachments/assets/d4338655-e2e6-4c6f-b2b2-6051393c3472

Before Convert:

![image](https://github.com/user-attachments/assets/38fc8a65-1ee9-4f34-8e88-859c85281ba2)

After Convert:

![image](https://github.com/user-attachments/assets/7199bbf3-7595-49dd-b619-de1fea692b74)

