### PR TITLE
fix special sorting for targets so DEFAULT is always last

### DIFF
--- a/Clicked/Core/BindingProcessor.lua
+++ b/Clicked/Core/BindingProcessor.lua
@@ -383,9 +383,9 @@ local function SortActions(actions, indexMap)
 			-- 3. Any actions that do not meet any of the criteria in this list will be placed here
 
 			-- 4. The player, cursor, and default targets will always come last
-			{ left = left.unit, right = right.unit, value = Addon.TargetUnit.PLAYER, comparison = "neq" },
+			{ left = left.unit, right = right.unit, value = Addon.TargetUnit.DEFAULT, comparison = "neq" },
 			{ left = left.unit, right = right.unit, value = Addon.TargetUnit.CURSOR, comparison = "neq" },
-			{ left = left.unit, right = right.unit, value = Addon.TargetUnit.DEFAULT, comparison = "neq" }
+			{ left = left.unit, right = right.unit, value = Addon.TargetUnit.PLAYER, comparison = "neq" },
 		}
 
 		for _, item in ipairs(priority) do


### PR DESCRIPTION
After 272c3ec4bcfa7ba29cfe9a4e14af4aeb66bd2624 bindings with targets Cursor/Player -> Default broke because default had higher priority than cursor/player.

![image](https://github.com/user-attachments/assets/edba32c4-be59-42d6-83bb-bb90fb4dbd22)
![image](https://github.com/user-attachments/assets/11f4a389-f73f-44a3-8bca-54d9fa6b6ae0)

My changes ensures that according to the comment priority is player > cursor > default


