### PR TITLE
Rename ClickedInternal to Addon

### DIFF
--- a/Clicked/BindingConfig/BindingConfig.lua
+++ b/Clicked/BindingConfig/BindingConfig.lua
@@ -30,7 +30,7 @@
 
 local AceGUI = LibStub("AceGUI-3.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local SEARCH_FILTER_APPLY_DELAY = 0.1

--- a/Clicked/BindingConfig/Conditions/InputDrawer.lua
+++ b/Clicked/BindingConfig/Conditions/InputDrawer.lua
@@ -16,7 +16,7 @@
 
 local AceGUI = LibStub("AceGUI-3.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Helpers = Addon.BindingConfig.Helpers

--- a/Clicked/BindingConfig/Conditions/MultiselectDrawer.lua
+++ b/Clicked/BindingConfig/Conditions/MultiselectDrawer.lua
@@ -16,7 +16,7 @@
 
 local AceGUI = LibStub("AceGUI-3.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Helpers = Addon.BindingConfig.Helpers

--- a/Clicked/BindingConfig/Conditions/SelectDrawer.lua
+++ b/Clicked/BindingConfig/Conditions/SelectDrawer.lua
@@ -16,7 +16,7 @@
 
 local AceGUI = LibStub("AceGUI-3.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Helpers = Addon.BindingConfig.Helpers

--- a/Clicked/BindingConfig/Conditions/TalentDrawer.lua
+++ b/Clicked/BindingConfig/Conditions/TalentDrawer.lua
@@ -16,7 +16,7 @@
 
 local AceGUI = LibStub("AceGUI-3.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Helpers = Addon.BindingConfig.Helpers

--- a/Clicked/BindingConfig/Conditions/ToggleDrawer.lua
+++ b/Clicked/BindingConfig/Conditions/ToggleDrawer.lua
@@ -16,7 +16,7 @@
 
 local AceGUI = LibStub("AceGUI-3.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Helpers = Addon.BindingConfig.Helpers

--- a/Clicked/BindingConfig/Helpers.lua
+++ b/Clicked/BindingConfig/Helpers.lua
@@ -18,7 +18,7 @@ local AceGUI = LibStub("AceGUI-3.0")
 
 --- @alias TooltipTextValue string|string[]|fun(widget: AceGUIWidget):string[]
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local MIXED_TEXT_COLOR =  BLUE_FONT_COLOR

--- a/Clicked/BindingConfig/Pages/Binding.lua
+++ b/Clicked/BindingConfig/Pages/Binding.lua
@@ -31,7 +31,7 @@
 
 local AceGUI = LibStub("AceGUI-3.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Helpers = Addon.BindingConfig.Helpers

--- a/Clicked/BindingConfig/Pages/ExportString.lua
+++ b/Clicked/BindingConfig/Pages/ExportString.lua
@@ -16,7 +16,7 @@
 
 local AceGUI = LibStub("AceGUI-3.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 -- Private addon API

--- a/Clicked/BindingConfig/Pages/Group.lua
+++ b/Clicked/BindingConfig/Pages/Group.lua
@@ -16,7 +16,7 @@
 
 local AceGUI = LibStub("AceGUI-3.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Helpers = Addon.BindingConfig.Helpers

--- a/Clicked/BindingConfig/Pages/IconSelect.lua
+++ b/Clicked/BindingConfig/Pages/IconSelect.lua
@@ -16,7 +16,7 @@
 
 local AceGUI = LibStub("AceGUI-3.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local MEDIA_ADDON_NAME = "ClickedMedia2"

--- a/Clicked/BindingConfig/Pages/ImportString.lua
+++ b/Clicked/BindingConfig/Pages/ImportString.lua
@@ -16,7 +16,7 @@
 
 local AceGUI = LibStub("AceGUI-3.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 --- @param mode BindingConfigImportStringPageMode

--- a/Clicked/BindingConfig/Pages/New.lua
+++ b/Clicked/BindingConfig/Pages/New.lua
@@ -21,7 +21,7 @@ local GetSpecialization = C_SpecializationInfo.GetSpecialization or GetSpecializ
 -- Deprecated in 5.5.0
 local GetSpecializationInfo = C_SpecializationInfo.GetSpecializationInfo or GetSpecializationInfo
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local ItemTemplate = {

--- a/Clicked/BindingConfig/Tabs/Action.lua
+++ b/Clicked/BindingConfig/Tabs/Action.lua
@@ -16,7 +16,7 @@
 
 local AceGUI = LibStub("AceGUI-3.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Helpers = Addon.BindingConfig.Helpers

--- a/Clicked/BindingConfig/Tabs/Condition.lua
+++ b/Clicked/BindingConfig/Tabs/Condition.lua
@@ -25,7 +25,7 @@
 --- @field public Draw? fun(self: BindingConditionDrawer)
 --- @field public Update? fun(self: BindingConditionDrawer)
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 Addon.BindingConfig = Addon.BindingConfig or {}

--- a/Clicked/BindingConfig/Tabs/Macro.lua
+++ b/Clicked/BindingConfig/Tabs/Macro.lua
@@ -16,7 +16,7 @@
 
 local AceGUI = LibStub("AceGUI-3.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Helpers = Addon.BindingConfig.Helpers

--- a/Clicked/BindingConfig/Tabs/Status.lua
+++ b/Clicked/BindingConfig/Tabs/Status.lua
@@ -17,7 +17,7 @@
 local AceGUI = LibStub("AceGUI-3.0")
 local LibMacroSyntaxHighlight = LibStub("LibMacroSyntaxHighlight-1.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 -- Private addon API

--- a/Clicked/BindingConfig/Tabs/Target.lua
+++ b/Clicked/BindingConfig/Tabs/Target.lua
@@ -16,7 +16,7 @@
 
 local AceGUI = LibStub("AceGUI-3.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Helpers = Addon.BindingConfig.Helpers

--- a/Clicked/BindingConfig/Tabs/UnitAction.lua
+++ b/Clicked/BindingConfig/Tabs/UnitAction.lua
@@ -16,7 +16,7 @@
 
 local AceGUI = LibStub("AceGUI-3.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Helpers = Addon.BindingConfig.Helpers

--- a/Clicked/Conditions/ConditionRegistry.lua
+++ b/Clicked/Conditions/ConditionRegistry.lua
@@ -42,7 +42,7 @@
 --- @field public map table<string, Condition>
 --- @field public dependencyGraph table<string, string[]>
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 --- @param config Condition[]

--- a/Clicked/Conditions/ConditionUtils.lua
+++ b/Clicked/Conditions/ConditionUtils.lua
@@ -39,7 +39,7 @@ local LibTalentInfo = LibStub("LibTalentInfo-1.0")
 -- Deprecated in 5.5.0
 local GetSpecialization = C_SpecializationInfo.GetSpecialization or GetSpecialization
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 -- Private addon API

--- a/Clicked/Conditions/LoadConditions.lua
+++ b/Clicked/Conditions/LoadConditions.lua
@@ -14,7 +14,7 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 -- Deprecated in 5.5.0

--- a/Clicked/Conditions/MacroConditions.lua
+++ b/Clicked/Conditions/MacroConditions.lua
@@ -14,7 +14,7 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Utils = Addon.Condition.Utils

--- a/Clicked/Config/Addon.lua
+++ b/Clicked/Config/Addon.lua
@@ -19,7 +19,7 @@ local AceConfigDialog = LibStub("AceConfigDialog-3.0")
 local LibDBIcon = LibStub("LibDBIcon-1.0")
 local LibLog = LibStub("LibLog-1.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 --- @class AddonOptions

--- a/Clicked/Config/Blacklist.lua
+++ b/Clicked/Config/Blacklist.lua
@@ -17,7 +17,7 @@
 local AceConfig = LibStub("AceConfig-3.0")
 local AceConfigDialog = LibStub("AceConfigDialog-3.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local UNIT_FRAME_ADDON_MAPPING = {

--- a/Clicked/Config/KeyLayouts.lua
+++ b/Clicked/Config/KeyLayouts.lua
@@ -16,7 +16,7 @@
 
 ---@diagnostic disable: missing-fields
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 --- @class KeyButton

--- a/Clicked/Config/KeyVisualizer.lua
+++ b/Clicked/Config/KeyVisualizer.lua
@@ -16,7 +16,7 @@
 
 local AceGUI = LibStub("AceGUI-3.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local DEFAULT_KEYBOARD_LAYOUT = Addon.KeyboardLayouts.QWERTY

--- a/Clicked/Config/Profile.lua
+++ b/Clicked/Config/Profile.lua
@@ -20,7 +20,7 @@ local AceConfigRegistry = LibStub("AceConfigRegistry-3.0")
 local AceDBOptions = LibStub("AceDBOptions-3.0")
 local AceComm = LibStub("AceComm-3.0")
 
---- @class ClickedInternal : AceComm-3.0
+--- @class Addon : AceComm-3.0
 local Addon = select(2, ...)
 
 -- Share to target player

--- a/Clicked/Config/SpellLibrary.lua
+++ b/Clicked/Config/SpellLibrary.lua
@@ -19,7 +19,7 @@ local GetSpecialization = C_SpecializationInfo.GetSpecialization or GetSpecializ
 -- Deprecated in 5.5.0
 local GetSpecializationInfo = C_SpecializationInfo.GetSpecializationInfo or GetSpecializationInfo
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 --- @class SpellLibrary

--- a/Clicked/Core/AttributeHandler.lua
+++ b/Clicked/Core/AttributeHandler.lua
@@ -14,7 +14,7 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local hasTypeRelease = Addon.EXPANSION_LEVEL >= Addon.Expansion.DF or Addon.EXPANSION_LEVEL == Addon.Expansion.TBC

--- a/Clicked/Core/BindingProcessor.lua
+++ b/Clicked/Core/BindingProcessor.lua
@@ -17,7 +17,7 @@
 -- Added in 12.0.0
 local issecretvalue = issecretvalue or function(val) return false end
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 --- @enum ActionType

--- a/Clicked/Core/Clicked.lua
+++ b/Clicked/Core/Clicked.lua
@@ -18,7 +18,7 @@ local AceConsole = LibStub("AceConsole-3.0")
 local LibDataBroker = LibStub("LibDataBroker-1.1")
 local LibDBIcon = LibStub("LibDBIcon-1.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 Addon.L = LibStub("AceLocale-3.0"):GetLocale("Clicked2") --[[@as table<string,string>]]
 

--- a/Clicked/Core/CommandProcessor.lua
+++ b/Clicked/Core/CommandProcessor.lua
@@ -14,7 +14,7 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 Addon.MACRO_FRAME_HANDLER_NAME = "ClickedMacroFrameHandler"

--- a/Clicked/Core/Database.lua
+++ b/Clicked/Core/Database.lua
@@ -19,7 +19,7 @@ local LibDBIcon = LibStub("LibDBIcon-1.0")
 -- Deprecated in 5.5.0
 local GetSpecialization = C_SpecializationInfo.GetSpecialization or GetSpecialization
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 --- @enum DataObjectType

--- a/Clicked/Core/Init.lua
+++ b/Clicked/Core/Init.lua
@@ -14,7 +14,7 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 --- @enum ExpansionLevel

--- a/Clicked/Core/LocaleUtils.lua
+++ b/Clicked/Core/LocaleUtils.lua
@@ -27,7 +27,7 @@ local GetSpecializationInfo = C_SpecializationInfo.GetSpecializationInfo or GetS
 
 local LibTalentInfo = LibStub("LibTalentInfo-1.0")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 --- @type integer[]

--- a/Clicked/Core/Serializer.lua
+++ b/Clicked/Core/Serializer.lua
@@ -17,7 +17,7 @@
 local AceSerializer = LibStub("AceSerializer-3.0")
 local LibDeflate = LibStub("LibDeflate")
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local logger = Clicked2:CreateSystemLogger("Serializer")

--- a/Clicked/Core/StringUtils.lua
+++ b/Clicked/Core/StringUtils.lua
@@ -14,7 +14,7 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local characterCache = {}

--- a/Clicked/Core/Tooltips.lua
+++ b/Clicked/Core/Tooltips.lua
@@ -17,7 +17,7 @@
 -- Added in 12.0.0
 local issecretvalue = issecretvalue or function(val) return false end
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 --- @type number?

--- a/Clicked/Core/Upgrader.lua
+++ b/Clicked/Core/Upgrader.lua
@@ -1,6 +1,6 @@
 ---@diagnostic disable: undefined-field, assign-type-mismatch, inject-field, missing-fields
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 Addon.DATA_VERSION = 13

--- a/Clicked/Core/Utils.lua
+++ b/Clicked/Core/Utils.lua
@@ -21,7 +21,7 @@ local GetSpecialization = C_SpecializationInfo.GetSpecialization or GetSpecializ
 -- Deprecated in 5.5.0
 local GetSpecializationInfo = C_SpecializationInfo.GetSpecializationInfo or GetSpecializationInfo
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 Addon.TOOLTIP_SHOW_DELAY = 0.3

--- a/Clicked/Debug/StatusOutput.lua
+++ b/Clicked/Debug/StatusOutput.lua
@@ -21,7 +21,7 @@ local GetSpecialization = C_SpecializationInfo.GetSpecialization or GetSpecializ
 -- Deprecated in 5.5.0
 local GetSpecializationInfo = C_SpecializationInfo.GetSpecializationInfo or GetSpecializationInfo
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 --- @type Frame

--- a/Clicked/Definitions.lua
+++ b/Clicked/Definitions.lua
@@ -19,7 +19,7 @@
 --- @class Clicked : AceAddon, AceEvent-3.0
 --- @field public VERSION string
 
---- @class ClickedInternal : AceEvent-3.0
+--- @class Addon : AceEvent-3.0
 --- @field public L table<string,string>
 --- @field public db AceDBObject-3.0
 

--- a/Clicked/Media/Media.lua
+++ b/Clicked/Media/Media.lua
@@ -16,7 +16,7 @@
 
 local LSM = LibStub("LibSharedMedia-3.0");
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 Addon.Media = {

--- a/Clicked/UnitFrames/Blizzard.lua
+++ b/Clicked/UnitFrames/Blizzard.lua
@@ -14,7 +14,7 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 -- Local support functions

--- a/Clicked/UnitFrames/ClickCastFrames.lua
+++ b/Clicked/UnitFrames/ClickCastFrames.lua
@@ -14,7 +14,7 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 --- @type Button[]

--- a/Clicked/UnitFrames/ClickCastHeader.lua
+++ b/Clicked/UnitFrames/ClickCastHeader.lua
@@ -14,7 +14,7 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 -- Local support functions

--- a/Clicked/Widgets/AceGUIContainer-ClickedIconSelectorList.lua
+++ b/Clicked/Widgets/AceGUIContainer-ClickedIconSelectorList.lua
@@ -35,7 +35,7 @@ Plain container that scrolls its content and doesn't grow in height.
 --- @field public numRows number?
 --- @field public numColumns number?
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Type, Version = "ClickedIconSelectorList", 1

--- a/Clicked/Widgets/AceGUIContainer-ClickedTreeGroup.lua
+++ b/Clicked/Widgets/AceGUIContainer-ClickedTreeGroup.lua
@@ -39,7 +39,7 @@ Container that uses a tree control to switch between groups.
 --- @field public subtitle FontString
 --- @field public selected boolean
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Type, Version = "ClickedTreeGroup", 1

--- a/Clicked/Widgets/AceGUIWidget-ClickedAutoFillEditBox.lua
+++ b/Clicked/Widgets/AceGUIWidget-ClickedAutoFillEditBox.lua
@@ -33,7 +33,7 @@ EditBox Widget
 -- Deprecated in 11.0.0
 local GetSpellBookItemName = C_SpellBook.GetSpellBookItemName or GetSpellBookItemName
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Type, Version = "ClickedAutoFillEditBox", 1

--- a/Clicked/Widgets/AceGUIWidget-ClickedBindingImportList.lua
+++ b/Clicked/Widgets/AceGUIWidget-ClickedBindingImportList.lua
@@ -34,7 +34,7 @@
 --- @class ClickedBindingImportList.GroupItem : ClickedTreeGroupItem
 --- @field public group Group
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Type, Version = "ClickedBindingImportList", 1

--- a/Clicked/Widgets/AceGUIWidget-ClickedKeyVisualizerButton.lua
+++ b/Clicked/Widgets/AceGUIWidget-ClickedKeyVisualizerButton.lua
@@ -11,7 +11,7 @@
 --- @field private visible boolean
 --- @field private highlight boolean
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Type, Version = "ClickedKeyVisualizerButton", 1

--- a/Clicked/Widgets/AceGUIWidget-ClickedKeybinding.lua
+++ b/Clicked/Widgets/AceGUIWidget-ClickedKeybinding.lua
@@ -9,7 +9,7 @@ Set Keybindings in the Config UI.
 
 --- @class ClickedKeybinding : AceGUIKeybinding
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Type, Version = "ClickedKeybinding", 3

--- a/Clicked/Widgets/AceGUIWidget-ClickedSearchBox.lua
+++ b/Clicked/Widgets/AceGUIWidget-ClickedSearchBox.lua
@@ -15,7 +15,7 @@ Adds OnFocusGained and OnFocusLost callbacks.
 --- @field private tooltipHeader? string
 --- @field private tooltipSubtext? string
 
---- @class ClickedInternal
+--- @class Addon
 local Addon = select(2, ...)
 
 local Type, Version = "ClickedSearchBox", 2


### PR DESCRIPTION
Simplify naming, there's no real reason to call this `ClickedInternal`, as it won't conflict with any other class anyway.